### PR TITLE
Fix env loading priority and stabilize tests

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,8 +11,8 @@ import (
 // Priority order: .env.local > .env > system environment variables
 func LoadEnvFiles() error {
 	envFiles := []string{
-		".env",
 		".env.local",
+		".env",
 	}
 
 	for _, file := range envFiles {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,0 +1,98 @@
+package scheduler
+
+import "testing"
+
+func TestParseScheduleTime(t *testing.T) {
+	tests := []struct {
+		name          string
+		scheduleTime  string
+		expectedHour  int
+		expectedMin   int
+		expectedError bool
+	}{
+		{
+			name:         "valid time",
+			scheduleTime: "14:30",
+			expectedHour: 14,
+			expectedMin:  30,
+		},
+		{
+			name:         "midnight",
+			scheduleTime: "00:00",
+			expectedHour: 0,
+			expectedMin:  0,
+		},
+		{
+			name:         "end of day",
+			scheduleTime: "23:59",
+			expectedHour: 23,
+			expectedMin:  59,
+		},
+		{
+			name:          "invalid format - no colon",
+			scheduleTime:  "1430",
+			expectedError: true,
+		},
+		{
+			name:          "invalid format - too many parts",
+			scheduleTime:  "14:30:00",
+			expectedError: true,
+		},
+		{
+			name:          "invalid hour - too high",
+			scheduleTime:  "25:30",
+			expectedError: true,
+		},
+		{
+			name:          "invalid hour - negative",
+			scheduleTime:  "-1:30",
+			expectedError: true,
+		},
+		{
+			name:          "invalid minute - too high",
+			scheduleTime:  "14:60",
+			expectedError: true,
+		},
+		{
+			name:          "invalid minute - negative",
+			scheduleTime:  "14:-1",
+			expectedError: true,
+		},
+		{
+			name:          "non-numeric hour",
+			scheduleTime:  "ab:30",
+			expectedError: true,
+		},
+		{
+			name:          "non-numeric minute",
+			scheduleTime:  "14:cd",
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hour, minute, err := parseScheduleTime(tt.scheduleTime)
+
+			if tt.expectedError {
+				if err == nil {
+					t.Errorf("Expected error for input %q, but got none", tt.scheduleTime)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error for input %q: %v", tt.scheduleTime, err)
+				return
+			}
+
+			if hour != tt.expectedHour {
+				t.Errorf("Hour mismatch for %q: expected %d, got %d", tt.scheduleTime, tt.expectedHour, hour)
+			}
+
+			if minute != tt.expectedMin {
+				t.Errorf("Minute mismatch for %q: expected %d, got %d", tt.scheduleTime, tt.expectedMin, minute)
+			}
+		})
+	}
+}

--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -60,6 +60,10 @@ func InitDB(dbPath string) (*sql.DB, error) {
 		return nil, fmt.Errorf("failed to ping database: %w", err)
 	}
 
+	if _, err := db.Exec("PRAGMA foreign_keys = ON"); err != nil {
+		return nil, fmt.Errorf("failed to enable foreign keys: %w", err)
+	}
+
 	if _, err := db.Exec(schema); err != nil {
 		return nil, fmt.Errorf("failed to create schema: %w", err)
 	}

--- a/internal/store/encryption_test.go
+++ b/internal/store/encryption_test.go
@@ -1,13 +1,15 @@
 package store
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
 	"os"
 	"testing"
 )
 
 func TestEncryptDecryptPassword(t *testing.T) {
 	// Set up test encryption key
-	testKey := "dGVzdGtleTEyMzQ1Njc4OTBhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ej0="
+	testKey := "ZhRwyRc6+ScRvBqVGiiwRiIiahXh503NTHT7E2p/3WQ="
 	os.Setenv("APP_ENC_KEY", testKey)
 	defer os.Unsetenv("APP_ENC_KEY")
 
@@ -83,7 +85,7 @@ func TestEncryptDecryptPassword(t *testing.T) {
 
 func TestInvalidDecryption(t *testing.T) {
 	// Set up test encryption key
-	testKey := "dGVzdGtleTEyMzQ1Njc4OTBhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ej0="
+	testKey := "ZhRwyRc6+ScRvBqVGiiwRiIiahXh503NTHT7E2p/3WQ="
 	os.Setenv("APP_ENC_KEY", testKey)
 	defer os.Unsetenv("APP_ENC_KEY")
 
@@ -126,7 +128,7 @@ func TestInvalidDecryption(t *testing.T) {
 
 func TestGenerateEncryptionKey(t *testing.T) {
 	key := GenerateEncryptionKey()
-	
+
 	if len(key) == 0 {
 		t.Fatal("Generated key is empty")
 	}

--- a/internal/store/repository_test.go
+++ b/internal/store/repository_test.go
@@ -16,7 +16,7 @@ func setupTestDB(t *testing.T) (*sql.DB, *Repository) {
 		t.Fatal(err)
 	}
 	tempFile.Close()
-	
+
 	t.Cleanup(func() {
 		os.Remove(tempFile.Name())
 	})
@@ -34,7 +34,7 @@ func setupTestDB(t *testing.T) (*sql.DB, *Repository) {
 }
 
 func setupTestEncryption(t *testing.T) {
-	testKey := "dGVzdGtleTEyMzQ1Njc4OTBhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ej0="
+	testKey := "ZhRwyRc6+ScRvBqVGiiwRiIiahXh503NTHT7E2p/3WQ="
 	os.Setenv("APP_ENC_KEY", testKey)
 	t.Cleanup(func() {
 		os.Unsetenv("APP_ENC_KEY")


### PR DESCRIPTION
## Summary
- Ensure `.env.local` overrides `.env` by adjusting environment file load order
- Enable SQLite foreign key enforcement and update tests for foreign key checks
- Use valid encryption keys and add missing crypto imports; relocate schedule parsing tests

## Testing
- `go test ./... -race -coverprofile=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_689782a916e4832094b334117a98f06e